### PR TITLE
Fix: Unlimited styles for grouping levels of reports

### DIFF
--- a/src/org/kopi/vkopi/lib/ui/vaadin/report/ReportCellStyleGenerator.java
+++ b/src/org/kopi/vkopi/lib/ui/vaadin/report/ReportCellStyleGenerator.java
@@ -50,7 +50,7 @@ public class ReportCellStyleGenerator implements CellStyleGenerator {
   public ReportCellStyleGenerator(MReport model, Parameters parameters) {
     this.model = model;
     this.parameters = parameters;
-    stylesMap = new CSSStyle[model.getAccessibleColumnCount() + 30][11];
+    stylesMap = new CSSStyle[model.getAccessibleColumnCount() + 30];
     updateStyles();
   }
   
@@ -59,18 +59,19 @@ public class ReportCellStyleGenerator implements CellStyleGenerator {
   //---------------------------------------------------
   
   @Override
-  public String getStyle(Table source, Object itemId, Object propertyId) { 
+  public String getStyle(Table source, Object itemId, Object propertyId) {
     int		level = model.getRow((Integer)itemId).getLevel();
-	    
+
     if (propertyId == null) {
       return null;
-    } else { 
+    } else {
       int col = ((Integer)propertyId).intValue();
       if (col > stylesMap.length-1) {
-	col = 0;
-      }    
-      
-      return stylesMap[col][level] == null ? null : stylesMap[col][level].getName();
+        col = 0;
+      }
+
+      stylesMap[col].setLevel(level);
+      return stylesMap[col] == null ? null : stylesMap[col].getName();
     }
   }
 
@@ -78,31 +79,29 @@ public class ReportCellStyleGenerator implements CellStyleGenerator {
    * Updates the columns styles.
    */
   public void updateStyles() {
-    for (int i = 0; i < 11; i ++) {
-      for (int j = 0; j < model.getAccessibleColumnCount(); j ++) {
-        String align;
-        boolean separator = false;
-        VReportColumn column = model.getAccessibleColumn(j);
-        ColumnStyle[]	styles = (ColumnStyle[]) column.getStyles();
-      
-        if(column instanceof VSeparatorColumn){
-	  separator = true;
-        }
-      
-        if (column.getAlign()== Constants.ALG_RIGHT) {
-	  align = "right";
-        } else {
-	  align = "left"; 
-        }
-      
-        ColumnStyle style = styles[0];
-    
-	if (stylesMap[j][i] == null) {
-          stylesMap[j][i] = StyleGenerator.getStyle(UI.getCurrent(), parameters, style, i, j, align, separator);         
-	} else {
-	  stylesMap[j][i].updateStyle(style);
-	}
-      } 
+    for (int j = 0; j < model.getAccessibleColumnCount(); j ++) {
+      String align;
+      boolean separator = false;
+      VReportColumn column = model.getAccessibleColumn(j);
+      ColumnStyle[]	styles = (ColumnStyle[]) column.getStyles();
+
+      if(column instanceof VSeparatorColumn){
+        separator = true;
+      }
+
+      if (column.getAlign()== Constants.ALG_RIGHT) {
+        align = "right";
+      } else {
+        align = "left";
+      }
+
+      ColumnStyle style = styles[0];
+
+      if (stylesMap[j] == null) {
+        stylesMap[j] = StyleGenerator.getStyle(UI.getCurrent(), parameters, style, j, align, separator);
+      } else {
+        stylesMap[j].updateStyle(style);
+      }
     }
   }
 	  
@@ -112,5 +111,5 @@ public class ReportCellStyleGenerator implements CellStyleGenerator {
 	  
   private MReport				model;
   private Parameters 				parameters;
-  private CSSStyle[][]				stylesMap;
+  private CSSStyle[]				stylesMap;
 }

--- a/src/org/kopi/vkopi/lib/ui/vaadin/report/ReportCellStyleGenerator.java
+++ b/src/org/kopi/vkopi/lib/ui/vaadin/report/ReportCellStyleGenerator.java
@@ -71,6 +71,7 @@ public class ReportCellStyleGenerator implements CellStyleGenerator {
       }
 
       stylesMap[col].setLevel(level);
+      stylesMap[col].updateStyle();
       return stylesMap[col] == null ? null : stylesMap[col].getName();
     }
   }
@@ -97,11 +98,7 @@ public class ReportCellStyleGenerator implements CellStyleGenerator {
 
       ColumnStyle style = styles[0];
 
-      if (stylesMap[j] == null) {
-        stylesMap[j] = StyleGenerator.getStyle(UI.getCurrent(), parameters, style, j, align, separator);
-      } else {
-        stylesMap[j].updateStyle(style);
-      }
+      stylesMap[j] = StyleGenerator.getStyle(UI.getCurrent(), parameters, style, j, align, separator);
     }
   }
 	  

--- a/src/org/kopi/vkopi/lib/ui/vaadin/report/StyleGenerator.java
+++ b/src/org/kopi/vkopi/lib/ui/vaadin/report/StyleGenerator.java
@@ -100,6 +100,8 @@ public class StyleGenerator {
       this.parameters = parameters;
       this.align = align;
       this.columnStyle = columnStyle;
+      this.background = columnStyle.getBackground();
+      this.foreground = columnStyle.getForeground();
       this.fontSize = parameters.getFont().getSize();
       this.fontFamily = parameters.getFont().getName();
       setItalic(parameters.getFont().isItalic());

--- a/src/org/kopi/vkopi/lib/ui/vaadin/report/StyleGenerator.java
+++ b/src/org/kopi/vkopi/lib/ui/vaadin/report/StyleGenerator.java
@@ -147,9 +147,16 @@ public class StyleGenerator {
     
     /**
      * Updates the CSS style of a given {@link ColumnStyle}.
+     */
+    public void updateStyle() {
+      updateStyle(columnStyle);
+    }
+
+    /**
+     * Updates the CSS style of a given {@link ColumnStyle}.
      * @param columnStyle The {@link ColumnStyle}.
      */
-    public void updateStyle(ColumnStyle columnStyle) {   
+    public void updateStyle(ColumnStyle columnStyle) {
       if (columnStyle.getBackground() != this.columnStyle.getBackground()) {
 	background = columnStyle.getBackground();
       } else {

--- a/src/org/kopi/vkopi/lib/ui/vaadin/report/StyleGenerator.java
+++ b/src/org/kopi/vkopi/lib/ui/vaadin/report/StyleGenerator.java
@@ -42,7 +42,6 @@ public class StyleGenerator {
    * @param target The target {@link UI}.
    * @param parameters The styles parameters.
    * @param columnStyle The {@link ColumnStyle}.
-   * @param level The column level.
    * @param column The column index.
    * @param align The column alignment.
    * @param separator Is it a separator column ? 
@@ -51,12 +50,11 @@ public class StyleGenerator {
   public static CSSStyle getStyle(UI target,
                                   Parameters parameters,
                                   ColumnStyle columnStyle,
-                                  int level,
                                   int column,
                                   String align,
                                   boolean separator)
   {
-    return new CSSStyle(target, parameters, columnStyle, level, column, align, separator);
+    return new CSSStyle(target, parameters, columnStyle, column, align, separator);
   }
 
   /**
@@ -86,7 +84,6 @@ public class StyleGenerator {
      * @param target The target {@link UI}.
      * @param parameters The styles parameters.
      * @param columnStyle The {@link ColumnStyle}.
-     * @param level The column level.
      * @param column The column index.
      * @param align The column alignment.
      * @param separator Is it a separator.
@@ -94,19 +91,15 @@ public class StyleGenerator {
     public CSSStyle(final UI target,
                     final Parameters parameters,
                     final ColumnStyle columnStyle,
-                    final int level,
                     final int column,
                     final String align,
                     final boolean separator)
     {
-      this.level = level;
       this.column = column;
       this.separator = separator; 
       this.parameters = parameters;
       this.align = align;
       this.columnStyle = columnStyle;
-      this.background = parameters.getBackground(level);
-      this.foreground = parameters.getForeground(level);
       this.fontSize = parameters.getFont().getSize();
       this.fontFamily = parameters.getFont().getName();
       setItalic(parameters.getFont().isItalic());
@@ -242,12 +235,22 @@ public class StyleGenerator {
 	this.fontWeight = "normal";
       }
     }
+
+    /**
+     * Sets the column level.
+     * @param level The column level.
+     */
+    public void setLevel(int level) {
+      this.level = level;
+      this.background = parameters.getBackground(level);
+      this.foreground = parameters.getForeground(level);
+    }
     
     //---------------------------------------
     // DATA MEMBERS
     //---------------------------------------
     
-    private final int			level;
+    private int			level;
     private final int			column;
     private CSSInject			style;
     private final boolean               separator;


### PR DESCRIPTION
Changes done in Vaadin implementation:

- 10 colors was defined for different grouping levels
- Falling back to white color if there are more that 10 grouping levels instead of throwing `ArrayIndexOutOfBoundsException`