### PR TITLE
Fix IllegalArgumentException when sorting application modules

### DIFF
--- a/src/org/kopi/vkopi/lib/visual/Module.java
+++ b/src/org/kopi/vkopi/lib/visual/Module.java
@@ -238,7 +238,7 @@ public class Module implements Comparable<Module> {
     if (priority == module.priority) {
       return description.compareTo(module.description);
     } else {
-      return priority - module.priority;
+      return Integer.compare(priority, module.priority);
     }
   }
 


### PR DESCRIPTION
This fixes the exception: 
`IllegalArgumentException: Comparison method violates its general contract!`