### PR TITLE
Fix executed action when pressing the TAB key while in and ENUM field (VCodeField) in Vaadin flow [APPS-02CX]

### DIFF
--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/base/JSUtils.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/base/JSUtils.kt
@@ -63,7 +63,7 @@ fun Component.inputValueExpression(): String {
   return when (this) {
     is VTimeField      -> "this.inputElement.value"
     is VTimeStampField -> "this.__datePicker.inputElement.value + ' ' + this.__timePicker.inputElement.value"
-    is VCodeField      -> "this.$.input.value"
+    is VCodeField      -> "this.inputElement.value"
     else               -> "this.value"
   }
 }

--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/base/JSUtils.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/base/JSUtils.kt
@@ -16,11 +16,12 @@
  */
 package org.kopi.vkopi.lib.ui.vaadinflow.base
 
-import org.kopi.vkopi.lib.ui.vaadinflow.field.VTimeField
-import org.kopi.vkopi.lib.ui.vaadinflow.field.VTimeStampField
-
 import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.KeyModifier
+
+import org.kopi.vkopi.lib.ui.vaadinflow.field.VCodeField
+import org.kopi.vkopi.lib.ui.vaadinflow.field.VTimeField
+import org.kopi.vkopi.lib.ui.vaadinflow.field.VTimeStampField
 
 fun Component.addJSKeyDownListener(shortCuts: MutableMap<String, ShortcutAction<*>>) {
   val jsCall = """
@@ -60,9 +61,10 @@ private fun Component.keysConditions(shortCuts: MutableMap<String, ShortcutActio
 
 fun Component.inputValueExpression(): String {
   return when (this) {
-    is VTimeField -> "this.inputElement.value"
+    is VTimeField      -> "this.inputElement.value"
     is VTimeStampField -> "this.__datePicker.inputElement.value + ' ' + this.__timePicker.inputElement.value"
-    else -> "this.value"
+    is VCodeField      -> "this.$.input.value"
+    else               -> "this.value"
   }
 }
 

--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/field/TextFieldNavigationHandler.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/field/TextFieldNavigationHandler.kt
@@ -105,7 +105,7 @@ open class TextFieldNavigationHandler protected constructor(private val isMulti:
     addKeyNavigator(field, Key.ARROW_UP, KeyModifier.of("Control")) {
       field.connector.firePreviousEntry()
     }
-    if (!isMulti) {
+    if (!isMulti && field !is VCodeField) {
       // In multiline fields these keys are used for other stuff
       addKeyNavigator(field, Key.ARROW_UP) {
         field.fieldConnector.gotoPrevField()

--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/field/VCodeField.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/field/VCodeField.kt
@@ -22,6 +22,7 @@ import java.util.Arrays
 import com.vaadin.flow.component.KeyNotifier
 import com.vaadin.flow.component.combobox.ComboBox
 import com.vaadin.flow.component.dependency.CssImport
+import com.vaadin.flow.data.provider.DataProvider
 
 /**
  * An Code field.
@@ -34,7 +35,7 @@ import com.vaadin.flow.component.dependency.CssImport
 class VCodeField(enumerations : Array<String>?) : InputTextField<ComboBox<String>>(ComboBox<String>()), KeyNotifier {
 
   init {
-    internalField.setItems(Arrays.stream(enumerations))
+    internalField.setItems(DataProvider.fromStream(Arrays.stream(enumerations)))
     element.themeList.add("galite-combobox")
   }
 

--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/form/DGridBlock.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/form/DGridBlock.kt
@@ -20,22 +20,6 @@ package org.kopi.vkopi.lib.ui.vaadinflow.form
 import java.awt.Color
 import java.util.stream.Stream
 
-import org.kopi.vkopi.lib.base.UComponent
-import org.kopi.vkopi.lib.form.Alignment
-import org.kopi.vkopi.lib.form.VActorField
-import org.kopi.vkopi.lib.form.VBlock
-import org.kopi.vkopi.lib.form.VBooleanField
-import org.kopi.vkopi.lib.form.VConstants
-import org.kopi.vkopi.lib.form.VField
-import org.kopi.vkopi.lib.form.VFieldUI
-import org.kopi.vkopi.lib.ui.vaadinflow.base.BackgroundThreadHandler.access
-import org.kopi.vkopi.lib.ui.vaadinflow.block.BlockLayout
-import org.kopi.vkopi.lib.ui.vaadinflow.block.SingleComponentBlockLayout
-import org.kopi.vkopi.lib.ui.vaadinflow.grid.GridEditorField
-import org.kopi.vkopi.lib.visual.Action
-import org.kopi.vkopi.lib.visual.VColor
-import org.kopi.vkopi.lib.visual.VException
-
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.dependency.CssImport
 import com.vaadin.flow.component.grid.ColumnResizeEvent
@@ -59,6 +43,22 @@ import com.vaadin.flow.data.value.ValueChangeMode
 import com.vaadin.flow.function.SerializableConsumer
 import com.vaadin.flow.function.SerializablePredicate
 import com.vaadin.flow.internal.ExecutionContext
+
+import org.kopi.vkopi.lib.base.UComponent
+import org.kopi.vkopi.lib.form.Alignment
+import org.kopi.vkopi.lib.form.VActorField
+import org.kopi.vkopi.lib.form.VBlock
+import org.kopi.vkopi.lib.form.VBooleanField
+import org.kopi.vkopi.lib.form.VConstants
+import org.kopi.vkopi.lib.form.VField
+import org.kopi.vkopi.lib.form.VFieldUI
+import org.kopi.vkopi.lib.ui.vaadinflow.base.BackgroundThreadHandler.access
+import org.kopi.vkopi.lib.ui.vaadinflow.block.BlockLayout
+import org.kopi.vkopi.lib.ui.vaadinflow.block.SingleComponentBlockLayout
+import org.kopi.vkopi.lib.ui.vaadinflow.grid.GridEditorField
+import org.kopi.vkopi.lib.visual.Action
+import org.kopi.vkopi.lib.visual.VColor
+import org.kopi.vkopi.lib.visual.VException
 
 /**
  * Grid based chart block implementation.

--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/form/DListDialog.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/form/DListDialog.kt
@@ -20,6 +20,7 @@ package org.kopi.vkopi.lib.ui.vaadinflow.form
 import com.vaadin.flow.component.AttachEvent
 import com.vaadin.flow.component.Key
 import com.vaadin.flow.component.KeyDownEvent
+import com.vaadin.flow.component.KeyNotifier
 import com.vaadin.flow.component.KeyPressEvent
 import com.vaadin.flow.component.Shortcuts
 import com.vaadin.flow.component.UI
@@ -52,7 +53,7 @@ import org.kopi.vkopi.lib.visual.VlibProperties
  *
  * @param model The list dialog model.
  */
-class DListDialog(private val model: VListDialog) : GridListDialog(), UListDialog { /*, CloseListener, SelectionListener, SearchListener TODO*/
+class DListDialog(private val model: VListDialog) : GridListDialog(), KeyNotifier, UListDialog { /*, CloseListener, SelectionListener, SearchListener TODO*/
   private var escaped = true
   private var doNewForm = false
   private var selectedPos = -1
@@ -328,17 +329,16 @@ class DListDialog(private val model: VListDialog) : GridListDialog(), UListDialo
     this.newForm = model.newForm != null || model.isForceNew
     super.table = table
     table.select(tableItems.first())
+    table.element.setAttribute("tabindex", "0")  // Make the element focusable
     (table.selectionModel as GridSingleSelectionModel).addSingleSelectionListener {
       if (it.isFromClient) {
         doSelectFromDialog(tableItems.indexOf(it.value ?: it.oldValue), false, false)
       }
     }
-    Shortcuts.addShortcutListener(this,
-                                  { _ -> doSelectFromDialog(tableItems.indexOf(table.selectedItem), escaped = false, doNewForm = false) },
-                                  Key.ENTER)
-    Shortcuts.addShortcutListener(this, { _ -> doSelectFromDialog(-1, escaped = false, doNewForm = true) }, Key.SPACE)
-    Shortcuts.addShortcutListener(this, { _ -> table.select(nextItem) }, Key.ARROW_DOWN)
-    Shortcuts.addShortcutListener(this, { _ -> table.select(previousItem) }, Key.ARROW_UP)
+    if (this.newForm) {
+      Shortcuts.addShortcutListener(this, { _ -> doSelectFromDialog(-1, escaped = false, doNewForm = true) }, Key.SPACE)
+    }
+    table.addKeyDownListener(::onKeyDown)
     table.addColumnReorderListener { sort(it.columns) }
   }
 
@@ -348,6 +348,7 @@ class DListDialog(private val model: VListDialog) : GridListDialog(), UListDialo
   internal fun showDialogAndWait() {
     startAndWaitAndPush(lock, currentUI) {
       showListDialog()
+      table?.focus()
     }
   }
 

--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/list/GridListDialog.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/list/GridListDialog.kt
@@ -19,7 +19,6 @@ package org.kopi.vkopi.lib.ui.vaadinflow.list
 
 import com.vaadin.flow.component.HasEnabled
 import com.vaadin.flow.component.HasStyle
-import com.vaadin.flow.component.KeyNotifier
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.dependency.CssImport
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
@@ -38,7 +37,7 @@ import org.kopi.vkopi.lib.visual.VlibProperties
   CssImport("./styles/galite/list.css" , themeFor = "vaadin-grid"),
   CssImport("./styles/galite/list.css" , themeFor = "vcf-enhanced-dialog-overlay")
 ])
-open class GridListDialog : Dialog(), HasEnabled, KeyNotifier, HasStyle {
+open class GridListDialog : Dialog(), HasEnabled, HasStyle {
 
   protected var newForm: Boolean = false
   protected var newFormButton: Button = Button(VlibProperties.getString("new-record"))

--- a/src/org/kopi/vkopi/lib/ui/vaadinflow/list/ListTable.kt
+++ b/src/org/kopi/vkopi/lib/ui/vaadinflow/list/ListTable.kt
@@ -19,6 +19,8 @@ package org.kopi.vkopi.lib.ui.vaadinflow.list
 
 import org.kopi.vkopi.lib.form.VListDialog
 
+import com.vaadin.flow.component.ComponentEventListener
+import com.vaadin.flow.component.KeyDownEvent
 import com.vaadin.flow.component.Unit
 import com.vaadin.flow.component.dependency.CssImport
 import com.vaadin.flow.component.grid.Grid
@@ -83,6 +85,15 @@ class ListTable(val model: VListDialog) : Grid<ListTable.ListDialogItem>() {
     (dataProvider as ListDataProvider).filter = ListFilter(filterFields, model, true, false)
 
     element.classList.add("filtered")
+  }
+
+  /**
+   * Adds a keydown listener to this component.
+   * @param listener
+   * @return a handle that can be used for removing the listener
+   */
+  fun addKeyDownListener(listener: ComponentEventListener<KeyDownEvent>) {
+    this.addListener(KeyDownEvent::class.java, listener)
   }
 
   /**


### PR DESCRIPTION
When using Vaadin flow for fields of type enumeration in Kopi forms, pressing the TAB key to autocomplete the filling of the field does not work. Autofill returns the INT key of the value instead of the value itself.

This pull request fixes this to use the defaut functionalities of ComboBox of Vaadin flow